### PR TITLE
Pin version of opt_einsum

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ REQUIRED_PACKAGES = (
     "tables",
     "h5py==3.2.1",
     "optax==0.0.9",
-
+    "opt_einsum==3.3.0",
 )
 
 setup(


### PR DESCRIPTION
Newer version of opt_einsum leads to error:
```
TypeError: Field elements must be 2- or 3-tuples, got 'Traced<...>'
```